### PR TITLE
build: regenerate uv.lock against github.com/openshift sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dev = ["ruff>=0.6", "pytest-xdist>=3"]
 
 [tool.uv.sources]
 traust-contracts = { git = "https://github.com/openshift/traust-contracts.git", rev = "04840f0ff852df59e1e83ac4a392b6d05a1f2ff6" }
-traust-engine = { git = "https://github.com/openshift/traust-engine.git", rev = "205274ba01d50d9adbadd753fea0a6273dd859e2" }
-traust-ledger = { git = "https://github.com/openshift/traust-ledger.git", rev = "ba503335f12bfa7a95d4af8c4224b9b0719291ca" }
+traust-engine = { git = "https://github.com/openshift/traust-engine.git", rev = "38cedef797a142f9b09def88330b92cf5422a987" }
+traust-ledger = { git = "https://github.com/openshift/traust-ledger.git", rev = "0f4553f21f6ad20e551cf4457927c957acc927ae" }
 
 # Multi-skill CLIs live under src/traust/; harnessing/<skill>/ for single-skill
 # scripts. Install for deps + importable path helpers.

--- a/uv.lock
+++ b/uv.lock
@@ -1126,7 +1126,7 @@ wheels = [
 
 [[package]]
 name = "traust"
-version = "0.347.4"
+version = "0.347.13"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },
@@ -1164,8 +1164,8 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "referencing" },
     { name = "sigstore", marker = "extra == 'signing'", specifier = ">=4.0,<5.0" },
-    { name = "traust-contracts", git = "ssh://git@gitlab.cee.redhat.com/hybrid-platforms-sec/traust-contracts.git?tag=v1.2.0" },
-    { name = "traust-engine", git = "ssh://git@gitlab.cee.redhat.com/hybrid-platforms-sec/traust-engine.git?tag=v0.12.3" },
+    { name = "traust-contracts", git = "https://github.com/openshift/traust-contracts.git?rev=04840f0ff852df59e1e83ac4a392b6d05a1f2ff6" },
+    { name = "traust-engine", git = "https://github.com/openshift/traust-engine.git?rev=38cedef797a142f9b09def88330b92cf5422a987" },
     { name = "tree-sitter", marker = "extra == 'graph'" },
     { name = "tree-sitter-go", marker = "extra == 'graph'" },
     { name = "tree-sitter-javascript", marker = "extra == 'graph'" },
@@ -1182,8 +1182,8 @@ dev = [
 
 [[package]]
 name = "traust-contracts"
-version = "1.2.0"
-source = { git = "ssh://git@gitlab.cee.redhat.com/hybrid-platforms-sec/traust-contracts.git?tag=v1.2.0#6ad98b12a31abbd79b739bd0bdb85e2f5fe504cd" }
+version = "1.2.2"
+source = { git = "https://github.com/openshift/traust-contracts.git?rev=04840f0ff852df59e1e83ac4a392b6d05a1f2ff6#04840f0ff852df59e1e83ac4a392b6d05a1f2ff6" }
 dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
@@ -1192,8 +1192,8 @@ dependencies = [
 
 [[package]]
 name = "traust-engine"
-version = "0.12.3"
-source = { git = "ssh://git@gitlab.cee.redhat.com/hybrid-platforms-sec/traust-engine.git?tag=v0.12.3#1d0fa92a5a219a9bd069bf4a0efa5041d2d628c3" }
+version = "0.12.8"
+source = { git = "https://github.com/openshift/traust-engine.git?rev=38cedef797a142f9b09def88330b92cf5422a987#38cedef797a142f9b09def88330b92cf5422a987" }
 dependencies = [
     { name = "jsonschema" },
     { name = "pyyaml" },
@@ -1204,8 +1204,8 @@ dependencies = [
 
 [[package]]
 name = "traust-ledger"
-version = "0.21.0"
-source = { git = "ssh://git@gitlab.cee.redhat.com/hybrid-platforms-sec/traust-ledger.git?tag=v0.21.0#83c29ef3b6e47385bff07cab357457ce16197198" }
+version = "0.21.5"
+source = { git = "https://github.com/openshift/traust-ledger.git?rev=0f4553f21f6ad20e551cf4457927c957acc927ae#0f4553f21f6ad20e551cf4457927c957acc927ae" }
 dependencies = [
     { name = "jsonschema" },
     { name = "pyjwt", extra = ["crypto"] },


### PR DESCRIPTION
Completes #3, which merged while still a draft. `uv.lock` still carried five `ssh://git@gitlab.cee.redhat.com` entries because it could not be regenerated until traust-engine's and traust-ledger's own sources pointed at GitHub (done in traust-engine#4 and traust-ledger#2).

- `traust-engine` pinned at merged main `38cedef` (v0.12.8), `traust-ledger` at `0f4553f` (v0.21.5), `traust-contracts` unchanged at `04840f0` (the rev both dependencies pin).
- `uv lock` regenerated: zero internal hosts remain. `uv sync` succeeds.
- Test suite: 769 passed; the one failure (`test_check_skill_alignment::test_current_tree_aligned`) is pre-existing on `main` and unrelated to this change.

A fresh public clone of this branch followed by `uv sync` was verified to work with no SSH keys and no internal network (see PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)