### PR TITLE
docs: refer to the deployer's private config repo generically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ harnessing/pqc-readiness/scripts/
 
 # mine-ledger rule-drafts are generated output (emit_rule_drafts.py default
 # --out-dir); they carry per-finding provenance and regenerate from the ledger,
-# so they are never committed. Estate copies live in the private traust-internal.
+# so they are never committed. Deployments keep their copies in their private
+# configuration repository.
 harnessing/mine-ledger/rule-drafts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ The agent runs from a parent workspace with three sibling trees (the inputs inve
 deployment-specific file. The real corpus registry, product map, budget policy,
 safe-exec profiles, rule-pack allowlist, hardening weights, dist-git watch list,
 internal vocabulary and ledger signing key live in the directory named by
-**`TRAUST_CONFIG_HOME`** (default `~/.traust/config`; for this estate the
-`traust-internal` repo's `config/`, set by the orchestrator). `scripts/install_traust`
+**`TRAUST_CONFIG_HOME`** (default `~/.traust/config`; a deployment usually points it
+at its own private configuration repository, set by the orchestrator). `scripts/install_traust`
 creates that directory from the templates and is the documented starting point;
 `install_traust --doctor` checks it. Resolve every such file through
 `config_path("<name>")` from `traust.paths` (or

--- a/harnessing/traust-metrics/SKILL.md
+++ b/harnessing/traust-metrics/SKILL.md
@@ -130,5 +130,5 @@ An earlier revision of this skill claimed the scoreboard harvested
 (docs-verification 2026-07-31, wiring c5). When reporting scoreboard
 numbers, point spend questions at the spend dashboard; treat a
 >7-day-old spend dashboard as stale and rebuild via
-`/refresh-dashboards`. Real-time view and the full tracking chain:
-`traust-internal/docs/spend-tracking.md`.
+`/refresh-dashboards`. Real-time view and the full tracking chain live in your
+deployment's private configuration repository, if it keeps one.

--- a/src/traust/cli/check_docs_consistency.py
+++ b/src/traust/cli/check_docs_consistency.py
@@ -79,7 +79,6 @@ SIBLING_PREFIXES = (
     "contracts/",
     "traust-ledger/",
     "schema/",
-    "traust-internal/",
 )
 GLOB_CHARS = set("*?<>{}|")
 

--- a/tests/test_check_skill_security.py
+++ b/tests/test_check_skill_security.py
@@ -319,7 +319,7 @@ class TestStageDepthExemptionMatching:
 
     # Injects its own key rather than borrowing a live one. These tests
     # previously used the validate-operator-live S6 exemption as a fixture and
-    # broke the moment that skill moved to traust-internal and the entry was
+    # broke the moment that skill moved to the private extension repo and the entry was
     # pruned — a mechanism test should not depend on which exemptions happen
     # to exist today.
     KEY = ("S6", "harnessing/fixture-skill/run_one.sh")
@@ -354,8 +354,8 @@ def test_no_stale_exemptions():
 
     A stale entry reads as a reviewed decision that still applies while
     silently protecting nothing. Five were found the first time this ran: a
-    fuzz harness that moved to the corpus, two skills that moved to
-    traust-internal, a path in a sibling repo this checker never scans, and one
+    fuzz harness that moved to the corpus, two skills that moved to the
+    private extension repo, a path in a sibling repo this checker never scans, and one
     whose underlying issue had simply been fixed. The only prior signal was a
     count of matched FILES, which drifts for unrelated reasons.
     """

--- a/tests/test_p2_hardening.py
+++ b/tests/test_p2_hardening.py
@@ -80,7 +80,7 @@ def test_e2_no_authorization_header_in_curl_argv():
 # now lives in the internal extension repo (open-source-upstream-plan.md
 # Phase 4). The assertions travel with the scripts — keeping them here would
 # leave two tests permanently red, and deleting them would drop the coverage
-# silently. See traust-internal/tests/.
+# silently. They live in the private extension repo's test suite.
 
 
 def test_e9_pqc_build_dir():
@@ -115,7 +115,7 @@ def test_d2_d6_allowlists_present():
     # validate-operator-live and validate-core-ocp assert in the internal
     # extension repo's copy of this test — see Phase 4 of the upstream plan.
     # deploy-operator asserts in the internal extension repo's copy since its
-    # 2026-09-07 move (traust-internal/tests/test_deploy_operator_hardening.py).
+    # 2026-09-07 move to that repo's test_deploy_operator_hardening.py.
     for skill in ("track-findings", "validate-findings", "fleet-fix"):
         s = (skill_dir(skill) / "SKILL.md").read_text()
         assert "allowed-tools:" in s.split("---")[1], skill


### PR DESCRIPTION
Public docs, docstrings and comments named the private `traust-internal` repository, which readers of the public project cannot open. Reworded as "the deployer's private configuration / extension repository", matching the `TRAUST_CONFIG_HOME` split already described in `docs/setup.md`. No behaviour change; the one code edit removes a now-unused prefix from the docs link-check skip list.

Follow-up to the 2026-09-08 publication gap assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)