### PR TITLE
docs: generic GitLab host wording in two docstrings

### DIFF
--- a/src/traust/migrations/export_gitlab_sast.py
+++ b/src/traust/migrations/export_gitlab_sast.py
@@ -5,7 +5,7 @@
 GitLab's Vulnerability Report / security dashboards do not ingest SARIF
 natively — they want the GitLab security-report JSON schema
 (https://gitlab.com/gitlab-org/security-products/security-report-schemas,
-targeted major: v15). This is the gitlab.cee counterpart of
+targeted major: v15). This is the GitLab counterpart of
 `export_sarif.py` (SARIF plan P2,;
 progress-tracker/plans/sarif-integration-plan.md), and the same
 invariants hold:

--- a/src/traust/ops/cve_replay_monitor.py
+++ b/src/traust/ops/cve_replay_monitor.py
@@ -236,7 +236,7 @@ def osv_identity(repo_url):
     GitHub repos map to their Go module identity
     (github.com/<org>/<name>) — the dominant portfolio ecosystem and the
     same identity convention run_fork_advisory_lag.py queries OSV with.
-    Non-GitHub hosts (gitlab.cee etc.) have no public OSV surface and
+    Non-GitHub hosts (self-hosted GitLab etc.) have no public OSV surface and
     are skipped, exactly as the 0a backfill skipped them.
     """
     if not repo_url:


### PR DESCRIPTION
Two module docstrings (`src/traust/migrations/export_gitlab_sast.py`, `src/traust/ops/cve_replay_monitor.py`) named the pre-publication internal GitLab host as an example. Reworded to "GitLab" / "self-hosted GitLab". Comment-only, no behaviour change. Last two `gitlab.cee` mentions under `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)