### PR TITLE
build: declare license = Apache-2.0 in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ name = "traust"
 # version-sync check fails the pre-push when they drift (and fails
 # closed if this field is removed)
 version = "0.347.14"
+license = "Apache-2.0"
 description = "AI agent tooling for automated security audits of Red Hat Hybrid Platforms source code"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Adds the SPDX `license = \"Apache-2.0\"` field to `[project]`, matching `LICENSE` and the traust-contracts, traust-engine and traust-ledger packages. Metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)