### PR TITLE
fix(remediate-finding): resolve private-forge hosts from config, not source

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -22,7 +22,7 @@ ships a template for each such file:
 | Template here | Deployment file | Read by |
 |---|---|---|
 | `corpus-config.example.yaml` | `corpus-config.yaml` | `traust_engine.corpus.resolver`, `/census`, every dashboard |
-| `remediation.example.yaml` | `remediation.yaml` | `/remediate-finding` (private mirror org, naming prefix) — no shipped default for the org |
+| `remediation.example.yaml` | `remediation.yaml` | `/remediate-finding` (private mirror org, naming prefix, self-hosted forge hosts) — no shipped default for the org, and none for the forge hosts |
 | `campaign.example.yaml` | `campaign.yaml` | dashboards that cite a tracking reference (`/validation-fuzz-dashboard`, `/generate-team-report`) |
 | `product-definitions-map.example.yaml` | `product-definitions-map.yaml` | `traust_engine.registry.products`, `/assign-findings-owners`, `/sla-view` |
 | `budget-policy.example.yaml` | `budget-policy.yaml` | `traust_engine.metrics.spend`, rescan worklist, drain tranche |

--- a/config/internal-vocabulary.example.yaml
+++ b/config/internal-vocabulary.example.yaml
@@ -38,7 +38,9 @@ rules:
   - id: internal-host
     tier: block
     why: internal hostname
-    pattern: '\b[a-z0-9][a-z0-9.-]*\.(?:corp|internal)\.yourorg\.invalid\b'
+    # leading subdomain optional — a bare `internal.yourorg.invalid` in code or
+    # prose discloses exactly as much as the full host
+    pattern: '\b(?:[a-z0-9][a-z0-9.-]*\.)?(?:corp|internal)\.yourorg\.invalid\b'
 
   # Case-SIGNIFICANT: a Kerberos realm is uppercase by convention. Compiled
   # IGNORECASE this matches every lowercase occurrence of the domain and

--- a/config/model-registry.yaml
+++ b/config/model-registry.yaml
@@ -49,10 +49,10 @@ providers:
     # cache_write ~1.25x input (5-min TTL; 1-hour TTL is ~2x).
     models:
       claude-mythos-5:        {tier: mythos-class, batch_eligible: true,  price_per_mtok_in: 10.0, price_per_mtok_out: 50.0}  # same rate card as claude-fable-5
-      claude-fable-5:         {tier: mythos-class, batch_eligible: true,  price_per_mtok_in: 10.0, price_per_mtok_out: 50.0}  # same rate card as claude-mythos-5; added 2026-07-28 so SCI's ratecard can consume the registry instead of hand-copying it (SCI PR #2 divergence)
+      claude-fable-5:         {tier: mythos-class, batch_eligible: true,  price_per_mtok_in: 10.0, price_per_mtok_out: 50.0}  # same rate card as claude-mythos-5; added 2026-07-28 so downstream rate-card consumers read the registry instead of hand-copying it
       claude-opus-5:          {tier: opus-class,   batch_eligible: true,  price_per_mtok_in: 5.0,  price_per_mtok_out: 25.0}  # corrected 2026-08-06 from 15/75 (stale Opus 4.1-era rate) to the published 5/25 — same bug already fixed for opus-4-8 below; verified against docs models overview. Overstated 2026-07 spend by ~$61K
       claude-opus-4-8:        {tier: opus-class,   batch_eligible: true,  price_per_mtok_in: 5.0,  price_per_mtok_out: 25.0}  # corrected from 15/75 (Opus 4.1-era rate) to published 5/25
-      claude-opus-4-6:        {tier: opus-class,   batch_eligible: true,  price_per_mtok_in: 5.0,  price_per_mtok_out: 25.0}  # not on the published rate card; empirically derived by SCI (test-pinned against a live CLI-reported $1.0016 session) — adopted 2026-07-28 to close the SCI ratecard split
+      claude-opus-4-6:        {tier: opus-class,   batch_eligible: true,  price_per_mtok_in: 5.0,  price_per_mtok_out: 25.0}  # not on the published rate card; empirically derived downstream (test-pinned against a live CLI-reported $1.0016 session) — adopted 2026-07-28 to close a rate-card split
       claude-sonnet-5:        {tier: sonnet-class, batch_eligible: true,  price_per_mtok_in: 3.0,  price_per_mtok_out: 15.0}
       claude-haiku-4-5-20251001: {tier: haiku-class, batch_eligible: true, price_per_mtok_in: 1.0, price_per_mtok_out: 5.0}
   # New vendors: data-handling + licensing intake FIRST (docs/

--- a/config/remediation.example.yaml
+++ b/config/remediation.example.yaml
@@ -10,5 +10,13 @@
 #   the control repo (<prefix>-control), fix branches (<prefix>/<id>/<slug>) and
 #   commit subjects. Change it only before the first batch; existing artefacts
 #   keep the prefix they were created with.
+# private_forge_hosts: hosts of Git forges you run yourself, whose repositories
+#   ARE the downstream fork — remediation lands in place instead of in a mirror
+#   under fork_org. Matched on the exact host or any subdomain of it; a bare
+#   hostname, or a URL to trim. Empty by default: naming your internal forge is
+#   deployment config, never something the harness ships. Override with
+#   HARNESS_PRIVATE_FORGE_HOSTS (comma-separated) in the environment.
 fork_org: example-org
 naming_prefix: traust
+private_forge_hosts: []
+#   - gitlab.example.internal

--- a/harnessing/7-remediate/remediate-finding/scripts/fork_map.py
+++ b/harnessing/7-remediate/remediate-finding/scripts/fork_map.py
@@ -14,6 +14,8 @@ Resolution order:
   3. Heuristic: ``https://github.com/<org>/<repo>`` →
      ``https://github.com/<fork_org>/<repo>``  (must already
      exist — this module never creates forks; that is ``ensure_fork.sh``'s job).
+  4. Heuristic: a repo on one of the deployment's own ``private_forge_hosts``
+     (remediation.yaml) is already the downstream fork — remediate in place.
 
 CLI:
   fork_map.py <upstream-url>            → JSON {fork_url, host, base_ref, …}
@@ -71,7 +73,7 @@ def default_fork_owner() -> str:
 class Fork:
     upstream_url: str
     fork_url: str
-    host: str = "github"  # github | gitlab | gitlab-cee | other
+    host: str = "github"  # github | private-forge | other
     visibility: str = "private"
     #: Branch in the fork to cut fix branches from.  ``__audited__`` is a
     #: sentinel meaning "use metadata.audited_commit from the manifest row"
@@ -102,7 +104,20 @@ FORKS: dict[str, Fork] = {}
 
 
 _GH = re.compile(r"^https://github\.com/(?P<org>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
-_GL = re.compile(r"^https://(?P<host>gitlab[^/]+)/(?P<org>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
+#: Host + path of any https repo URL — nested groups included, so a repo in a
+#: subgroup on a self-hosted forge still resolves.
+_HOST = re.compile(r"^https://(?P<host>[^/]+)/(?P<path>[^/].*)$")
+
+
+# Which forge hosts are the deployment's own is deployment config, not a
+# harness constant: a tool that ships an organisation's internal hostnames has
+# published them. Resolved lazily so importing this module never requires a
+# config home.
+def _is_private_forge(host: str) -> bool:
+    from traust.context import private_forge_hosts
+
+    h = host.strip().lower()
+    return any(h == p or h.endswith(f".{p}") for p in private_forge_hosts())
 
 
 def _norm(url: str) -> str:
@@ -147,13 +162,13 @@ def resolve(upstream_url: str) -> Fork:
             host="github",
             notes="heuristic — verify fork exists before use",
         )
-    if m := _GL.match(key):
-        host = "gitlab-cee" if "cee.redhat.com" in m["host"] else "gitlab"
-        # Internal GitLab repos ARE the downstream fork; remediate in-place.
+    if (m := _HOST.match(key)) and _is_private_forge(m["host"]):
+        # A repo on the deployment's own forge IS the downstream fork: remediate
+        # in place rather than mirroring it into a fork org.
         return Fork(
             upstream_url=key,
             fork_url=key,
-            host=host,
+            host="private-forge",
             visibility="internal",
             notes="private-forge repo — treated as its own downstream fork",
         )

--- a/src/traust/context.py
+++ b/src/traust/context.py
@@ -125,13 +125,37 @@ def _optional_config(name: str) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+def _normalise_host(value: str) -> str:
+    """``https://gitlab.example.com/group/`` → ``gitlab.example.com``."""
+    h = str(value).strip().lower()
+    h = h.split("://", 1)[-1]
+    h = h.split("/", 1)[0]
+    return h.strip(". ")
+
+
+def _private_forge_hosts(cfg: dict) -> tuple[str, ...]:
+    raw = os.environ.get("HARNESS_PRIVATE_FORGE_HOSTS")
+    if raw and raw.strip():
+        values: list = raw.split(",")
+    else:
+        values = cfg.get("private_forge_hosts") or []
+        if isinstance(values, str):
+            values = values.split(",")
+        elif not isinstance(values, list):
+            values = []
+    return tuple(dict.fromkeys(h for h in (_normalise_host(v) for v in values) if h))
+
+
 def remediation_settings() -> dict:
-    """remediate-finding's deployment settings — ``fork_org`` and
-    ``naming_prefix`` — from ``remediation.yaml`` in the config home, each
-    overridable by ``HARNESS_FORK_ORG`` / ``REMEDIATION_PREFIX`` in the
+    """remediate-finding's deployment settings — ``fork_org``,
+    ``naming_prefix`` and ``private_forge_hosts`` — from ``remediation.yaml``
+    in the config home, each overridable by ``HARNESS_FORK_ORG`` /
+    ``REMEDIATION_PREFIX`` / ``HARNESS_PRIVATE_FORGE_HOSTS`` in the
     environment. ``fork_org`` has no shipped default: the private mirror
     organisation is the adopter's (decision D5, 2026-09-07); callers fail loud
     when it is unset. ``naming_prefix`` defaults to ``traust``.
+    ``private_forge_hosts`` defaults to empty — naming an organisation's
+    internal forge is deployment config, never a shipped constant.
     """
     cfg = _optional_config("remediation.yaml")
     fork_org = os.environ.get("HARNESS_FORK_ORG") or str(cfg.get("fork_org") or "").strip()
@@ -140,7 +164,20 @@ def remediation_settings() -> dict:
     )
     if fork_org in ("", "example-org"):
         fork_org = ""
-    return {"fork_org": fork_org, "naming_prefix": prefix}
+    return {
+        "fork_org": fork_org,
+        "naming_prefix": prefix,
+        "private_forge_hosts": _private_forge_hosts(cfg),
+    }
+
+
+def private_forge_hosts() -> tuple[str, ...]:
+    """Hosts of self-hosted forges whose repositories ARE their own downstream
+    fork — remediation lands in place rather than in a mirror. Empty unless the
+    deployment lists them in ``remediation.yaml``; see
+    ``config/remediation.example.yaml``.
+    """
+    return remediation_settings()["private_forge_hosts"]
 
 
 def require_fork_org() -> str:

--- a/tests/fixtures/config/internal-vocabulary.yaml
+++ b/tests/fixtures/config/internal-vocabulary.yaml
@@ -36,7 +36,9 @@ rules:
   - id: internal-host
     tier: block
     why: internal hostname
-    pattern: '\b[a-z0-9][a-z0-9.-]*\.(?:corp|internal)\.yourorg\.invalid\b'
+    # leading subdomain optional — a bare `internal.yourorg.invalid` in code or
+    # prose discloses exactly as much as the full host
+    pattern: '\b(?:[a-z0-9][a-z0-9.-]*\.)?(?:corp|internal)\.yourorg\.invalid\b'
 
   # Case-SIGNIFICANT: a Kerberos realm is uppercase by convention. Compiled
   # IGNORECASE this matches every lowercase occurrence of the domain and

--- a/tests/test_fork_map.py
+++ b/tests/test_fork_map.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Tests for harnessing/7-remediate/remediate-finding/scripts/fork_map.py.
+
+The private-forge tier is deployment config (``remediation.yaml``): the
+harness ships no hostname of anyone's internal forge, and resolves nothing as
+"internal" until a deployment says which hosts are its own.
+"""
+
+import importlib.util
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from traust.context import remediation_settings
+from traust.paths import skill_dir
+
+FORK_MAP = skill_dir("remediate-finding") / "scripts" / "fork_map.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("fork_map_under_test", FORK_MAP)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod  # dataclasses resolves annotations via sys.modules
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _config_home(tmp_path: Path, remediation: dict) -> Path:
+    home = tmp_path / "cfg"
+    home.mkdir()
+    home.joinpath("locations.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "workspace": str(tmp_path / "ws"),
+                "analysis_results": str(tmp_path / "ar"),
+                "progress_tracker": str(tmp_path / "pt"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    for f in (Path(__file__).parent / "fixtures" / "config").iterdir():
+        if f.is_file():
+            shutil.copy2(f, home / f.name)
+    home.joinpath("remediation.yaml").write_text(yaml.safe_dump(remediation), encoding="utf-8")
+    return home
+
+
+@pytest.fixture
+def fork_map(tmp_path, monkeypatch, request):
+    settings = getattr(request, "param", {"fork_org": "mirror-org"})
+    home = _config_home(tmp_path, settings)
+    monkeypatch.setenv("TRAUST_CONFIG_HOME", str(home))
+    monkeypatch.delenv("HARNESS_FORK_ORG", raising=False)
+    monkeypatch.delenv("HARNESS_PRIVATE_FORGE_HOSTS", raising=False)
+    mod = _load_module()
+    mod.configure_paths(tmp_path / "ar")  # no fork-map.csv there — heuristics only
+    return mod
+
+
+PRIVATE = {"fork_org": "mirror-org", "private_forge_hosts": ["forge.example.internal"]}
+
+
+def test_github_repo_maps_into_the_configured_mirror_org(fork_map):
+    f = fork_map.resolve("https://github.com/some-org/some-repo.git")
+    assert f.fork_url == "https://github.com/mirror-org/some-repo"
+    assert f.host == "github"
+    assert f.visibility == "private"
+
+
+@pytest.mark.parametrize("fork_map", [PRIVATE], indirect=True)
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://forge.example.internal/group/repo",
+        "https://forge.example.internal/group/subgroup/repo.git",
+        "https://sub.forge.example.internal/group/repo",
+    ],
+)
+def test_configured_forge_host_is_its_own_downstream_fork(fork_map, url):
+    f = fork_map.resolve(url)
+    assert f.fork_url == f.upstream_url == url.removesuffix(".git")
+    assert f.host == "private-forge"
+    assert f.visibility == "internal"
+
+
+@pytest.mark.parametrize("fork_map", [PRIVATE], indirect=True)
+def test_forge_host_matches_the_host_only_not_a_lookalike_path(fork_map):
+    with pytest.raises(KeyError):
+        fork_map.resolve("https://evil.example.com/forge.example.internal/repo")
+
+
+def test_unconfigured_host_has_no_mapping(fork_map):
+    """No host is 'internal' by default — the tool knows nobody's forge."""
+    for url in (
+        "https://gitlab.com/some-org/some-repo",
+        "https://forge.example.internal/group/repo",
+        "https://git.example.org/group/repo",
+    ):
+        with pytest.raises(KeyError):
+            fork_map.resolve(url)
+
+
+def test_env_override_supplies_forge_hosts(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRAUST_CONFIG_HOME", str(_config_home(tmp_path, {"fork_org": "o"})))
+    monkeypatch.setenv("HARNESS_PRIVATE_FORGE_HOSTS", "https://Forge.Example.Internal/, other.host")
+    assert remediation_settings()["private_forge_hosts"] == (
+        "forge.example.internal",
+        "other.host",
+    )
+
+
+def test_no_hostname_of_any_deployment_is_hardcoded():
+    """Regression: fork_map.py once carried an internal forge's hostname.
+
+    A tool that ships an organisation's internal hostnames has published them,
+    so the only host literal allowed here is the public forge it heuristically
+    mirrors from.
+    """
+    source = FORK_MAP.read_text(encoding="utf-8").replace("\\.", ".")
+    hosts = re.findall(
+        r"\b[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:com|net|org|io|internal|corp|local)\b", source
+    )
+    assert set(hosts) <= {"github.com"}


### PR DESCRIPTION
`fork_map.py` hardcoded one deployment's internal forge domain. Any host matching `gitlab*` was treated as its own downstream fork, and the subset carrying that domain got the label `gitlab-cee`:

```python
host = "gitlab-cee" if "<internal domain>" in m["host"] else "gitlab"
```

A public repository is the wrong place to say which hosts are somebody's internal forge — same reasoning `scan_internal_refs` already applies to its vocabulary file ("a scanner shipping a list of an organization's internal tool names has published that list").

## What changed

The private-forge tier is now deployment config. `private_forge_hosts` in `remediation.yaml` — or `HARNESS_PRIVATE_FORGE_HOSTS`, comma-separated — lists the hosts whose repositories **are** the downstream fork. `fork_map` matches a host exactly or as a subdomain of a listed one and returns `host="private-forge"`. The list is empty by default, so the harness resolves no host as internal until a deployment says so.

Two behaviour changes fall out of that, both worth a look in review:

- **An unlisted GitLab host no longer resolves to itself** with `visibility: internal`. It raises `KeyError` like any other unmapped host. Previously *every* `gitlab*` host took that path, including `gitlab.com` — a public repository there was being treated as somebody's private downstream fork, which was never right.
- **Nested groups now resolve.** The match is on the host rather than a two-segment path, so `host/group/subgroup/repo` works.

No data migration: `host` is a free-form column in `fork-map.csv`, nothing branches on its value (`emit_remediation_report.py` recomputes it from the fork URL), so existing rows carrying the old label still load.

## Second commit

The pre-publication scrub should have caught this and didn't: the `internal-host` vocabulary rule required a leading subdomain, and the literal in `fork_map.py` was the bare domain. The shipped example and the test fixture now make the leading label optional.

While there, `model-registry.yaml`'s rate-card comments named an internal program by its abbreviation — `check docs-consistency` flags it as an estate marker in a shipped config file, and the comments read fine without it. Happy to split that into its own PR if you'd rather keep this single-purpose.

## Follow-ups found but not fixed here

Two things in `ensure_fork.sh` that touch the same seam and need a design call rather than a drive-by:

1. **`FORK_SSH_REWRITE_HOST` is unreachable.** It rewrites `CLONE_URL` to `git@host:path.git`, and the `https://`-only guard a few lines later (rule S3) then exits 1 with `refuse: non-https CLONE_URL`. Mirroring a private-forge upstream can't work today by either path — anonymous HTTPS clone of an internal repo fails, and the SSH escape hatch dies at the guard.
2. **`FORK_UPSTREAM_HOSTS` is set nowhere** in either repo. It answers a similar "which hosts are ours" question. I prototyped deriving it from `private_forge_hosts` and backed it out: the two aren't the same set (that one is hosts you *clone from* and includes `github.com`), and wiring it wouldn't unblock anything while (1) stands.

## Testing

`ruff check` + `format --check` clean. Full suite: 2313 passed, 54 skipped, 0 failures. All four checks CONTRIBUTING asks for pass — skill-alignment, skill-security, content-licenses, docs-consistency. `scan_internal_refs` reports zero block-tier host hits in `fork_map.py`.

New `tests/test_fork_map.py` covers both resolution tiers, the empty default, env-override normalization, and a guard that fails if a hostname literal reappears in the source (verified it bites by planting one).

The paired deployment config lands separately. Merge that first — between the two, `private_forge_hosts` is unset and internal-forge URLs raise `KeyError` instead of resolving in place.

---
🤖 This pull request description and the commits in it were generated by Claude (Claude Code), reviewed by @pshickeydev before submission.